### PR TITLE
Add a config option to always remove [[[]]]

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -70,6 +70,9 @@ I18nPlugin.prototype.apply = function(compiler) {
                                     if (typeof(replacement) === "undefined") {
                                         compilation.warnings.push(
                                             new Error(`Missing translation, '${m[1]}' : ${self.locale[0]}`));
+                                        if(self.options.alwaysRemoveBrackets){
+                                            source = source.replace(m[0], m[1]);
+                                        }
                                     } else {
                                         source = source.replace(m[0], replacement);
                                     }


### PR DESCRIPTION
This allows a workflow with partial translations (e.g. for different terminologies).  If the alwaysRemoveBrackets flag is set then the original string is retained by the brackets are removed.